### PR TITLE
fix: BP-5976 | Add github token to netrc file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - 12
 before_install:
   - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+  - echo -e "machine github.com\n  login $GH_TOKEN" > ~/.netrc
 
 script:
   - npm test


### PR DESCRIPTION
* Add github token to `~/.netrc` file for automatically pushing commits back to Github.